### PR TITLE
Fixes ordering of leaders for winning

### DIFF
--- a/src/main/kotlin/xyz/hyperspark/slayer/events/listeners/SlayerListener.kt
+++ b/src/main/kotlin/xyz/hyperspark/slayer/events/listeners/SlayerListener.kt
@@ -59,7 +59,7 @@ data class Winners (
 
 private fun calculateWinners(scores: Map<PlayerId, Points>): Winners {
     val topThreeEntries = scores.toList()
-        .sortedBy { (_, value) -> value }
+        .sortedByDescending { (_, value) -> value }
         .map { Some(it) }
         .take(3)
 


### PR DESCRIPTION
## Why

Final scoreboard was ordering players incorrectly :skull:

## What

Changed `sortedBy` to `sortedByDescending`

![facepalm](https://media0.giphy.com/media/yFQ0ywscgobJK/giphy.gif)